### PR TITLE
Add canvas filter for string type only

### DIFF
--- a/public/app/features/dimensions/editors/ResourceDimensionEditor.tsx
+++ b/public/app/features/dimensions/editors/ResourceDimensionEditor.tsx
@@ -1,7 +1,13 @@
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import * as React from 'react';
 
-import { FieldNamePickerConfigSettings, StandardEditorProps, StandardEditorsRegistryItem } from '@grafana/data';
+import {
+  Field,
+  FieldNamePickerConfigSettings,
+  FieldType,
+  StandardEditorProps,
+  StandardEditorsRegistryItem,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { ResourceDimensionConfig, ResourceDimensionMode } from '@grafana/schema';
 import { InlineField, InlineFieldRow, RadioButtonGroup } from '@grafana/ui';
@@ -84,6 +90,31 @@ export const ResourceDimensionEditor = (
     }
   }
 
+  // Create filter function that has access to current value
+  const fieldFilter = useMemo(() => {
+    // Use provided filter function if available
+    if (item.settings?.fieldFilter) {
+      return item.settings.fieldFilter;
+    }
+    // If filterStringFieldsOnly is true, create a filter that includes string fields and current selection
+    if (item.settings?.filterStringFieldsOnly) {
+      const currentFieldValue = value?.field;
+      return (field: Field) => {
+        // Include string fields
+        if (field.type === FieldType.string) {
+          return true;
+        }
+        // Include the currently selected field even if it's not a string
+        if (currentFieldValue && (field.name === currentFieldValue || field.state?.displayName === currentFieldValue)) {
+          return true;
+        }
+        return false;
+      };
+    }
+    // No filter
+    return undefined;
+  }, [item.settings?.fieldFilter, item.settings?.filterStringFieldsOnly, value?.field]);
+
   return (
     <>
       {showSourceRadio && (
@@ -108,7 +139,13 @@ export const ResourceDimensionEditor = (
               context={context}
               value={value.field ?? ''}
               onChange={onFieldChange}
-              item={dummyFieldSettings}
+              item={{
+                ...dummyFieldSettings,
+                settings: {
+                  ...dummyFieldSettings.settings,
+                  filter: fieldFilter,
+                },
+              }}
             />
           </InlineField>
         </InlineFieldRow>

--- a/public/app/features/dimensions/editors/ResourceDimensionEditor.tsx
+++ b/public/app/features/dimensions/editors/ResourceDimensionEditor.tsx
@@ -1,13 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import * as React from 'react';
 
-import {
-  Field,
-  FieldNamePickerConfigSettings,
-  FieldType,
-  StandardEditorProps,
-  StandardEditorsRegistryItem,
-} from '@grafana/data';
+import { Field, FieldNamePickerConfigSettings, StandardEditorProps, StandardEditorsRegistryItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { ResourceDimensionConfig, ResourceDimensionMode } from '@grafana/schema';
 import { InlineField, InlineFieldRow, RadioButtonGroup } from '@grafana/ui';
@@ -90,30 +84,25 @@ export const ResourceDimensionEditor = (
     }
   }
 
-  // Create filter function that has access to current value
+  // Create filter function that filters by field type and includes current selection
   const fieldFilter = useMemo(() => {
-    // Use provided filter function if available
-    if (item.settings?.fieldFilter) {
-      return item.settings.fieldFilter;
+    const filteredFieldType = item.settings?.filteredFieldType;
+    if (!filteredFieldType) {
+      return undefined;
     }
-    // If filterStringFieldsOnly is true, create a filter that includes string fields and current selection
-    if (item.settings?.filterStringFieldsOnly) {
-      const currentFieldValue = value?.field;
-      return (field: Field) => {
-        // Include string fields
-        if (field.type === FieldType.string) {
-          return true;
-        }
-        // Include the currently selected field even if it's not a string
-        if (currentFieldValue && (field.name === currentFieldValue || field.state?.displayName === currentFieldValue)) {
-          return true;
-        }
-        return false;
-      };
-    }
-    // No filter
-    return undefined;
-  }, [item.settings?.fieldFilter, item.settings?.filterStringFieldsOnly, value?.field]);
+    const currentFieldValue = value?.field;
+    return (field: Field) => {
+      // Include fields matching the filtered type
+      if (field.type === filteredFieldType) {
+        return true;
+      }
+      // Include the currently selected field even if it doesn't match the type
+      if (currentFieldValue && (field.name === currentFieldValue || field.state?.displayName === currentFieldValue)) {
+        return true;
+      }
+      return false;
+    };
+  }, [item.settings?.filteredFieldType, value?.field]);
 
   return (
     <>

--- a/public/app/features/dimensions/types.ts
+++ b/public/app/features/dimensions/types.ts
@@ -61,10 +61,8 @@ export interface ResourceDimensionOptions {
   // If you want your icon to be driven by value of a field
   showSourceRadio?: boolean;
   maxFiles?: number;
-  // Filter function for the field picker (used when mode is Field)
   fieldFilter?: (field: Field) => boolean;
-  // If true, filter to only show string fields (filter will be created with current value)
-  filterStringFieldsOnly?: boolean;
+  filteredFieldType?: FieldType;
 }
 
 export enum ResourceFolderName {

--- a/public/app/features/dimensions/types.ts
+++ b/public/app/features/dimensions/types.ts
@@ -61,6 +61,10 @@ export interface ResourceDimensionOptions {
   // If you want your icon to be driven by value of a field
   showSourceRadio?: boolean;
   maxFiles?: number;
+  // Filter function for the field picker (used when mode is Field)
+  fieldFilter?: (field: Field) => boolean;
+  // If true, filter to only show string fields (filter will be created with current value)
+  filterStringFieldsOnly?: boolean;
 }
 
 export enum ResourceFolderName {

--- a/public/app/plugins/panel/canvas/editor/options.ts
+++ b/public/app/plugins/panel/canvas/editor/options.ts
@@ -59,6 +59,9 @@ export const optionBuilder: OptionSuppliers = {
         editor: ResourceDimensionEditor,
         settings: {
           resourceType: 'image',
+          // Signal that we want to filter for string fields only
+          // The actual filter will be created in ResourceDimensionEditor with access to current value
+          filterStringFieldsOnly: true,
         },
       })
       .addCustomEditor({

--- a/public/app/plugins/panel/canvas/editor/options.ts
+++ b/public/app/plugins/panel/canvas/editor/options.ts
@@ -59,9 +59,7 @@ export const optionBuilder: OptionSuppliers = {
         editor: ResourceDimensionEditor,
         settings: {
           resourceType: 'image',
-          // Signal that we want to filter for string fields only
-          // The actual filter will be created in ResourceDimensionEditor with access to current value
-          filterStringFieldsOnly: true,
+          filteredFieldType: FieldType.string,
         },
       })
       .addCustomEditor({


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature adds a filter for the canvas panel image field picker to only allow for strings.

**Why do we need this feature?**

Currently, the field picker allows for selecting any field type, which causes runtime errors since only string fields are valid for image paths.

**Who is this feature for?**

This feature is for any dashboard user who wants to add an image field to their canvas

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #5 

**Special notes for your reviewer:**

Before filter:
<img width="346" height="639" alt="Screenshot 2026-01-25 at 11 18 42 AM" src="https://github.com/user-attachments/assets/c3c1aa6a-9579-4dc2-84fd-9edd27db3080" />


After:
<img width="354" height="646" alt="Screenshot 2026-01-25 at 11 19 27 AM" src="https://github.com/user-attachments/assets/995f8bf5-5ea6-4b56-90ba-3ac5e33b4ec8" />


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
